### PR TITLE
add weightless support

### DIFF
--- a/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
+++ b/include/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_options.h
@@ -39,6 +39,12 @@ constexpr const char* kCudaGraphEnable = "enable_cuda_graph";
 constexpr const char* kMultiProfileEnable = "nv_multi_profile_enable";
 constexpr const char* kUseExternalDataInitializer = "nv_use_external_data_initializer";
 constexpr const char* kRuntimeCacheFile = "nv_runtime_cache_path";
+constexpr const char* kWeightStrippedEngineEnable = "nv_weight_stripped_engine_enable";
+constexpr const char* kOnnxModelFolderPath = "nv_onnx_model_folder_path";
+constexpr const char* kONNXBytestream = "nv_onnx_bytestream";
+constexpr const char* kONNXBytestreamSize = "nv_onnx_bytestream_size";
+constexpr const char* kExternalDataBytestream = "nv_external_data_bytestream";
+constexpr const char* kExternalDataBytestreamSize = "nv_external_data_bytestream_size";
 constexpr const char* kExternalComputeQueueDataParamNV_data = "VkExternalComputeQueueDataParamsNV_data";
 
 }  // namespace provider_option_names

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2910,6 +2910,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] STRIP_PLAN is enabled";
     trt_config->setFlag(nvinfer1::BuilderFlag::kREFIT_IDENTICAL);
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] REFIT_IDENTICAL is enabled";
+    weight_stripped_engine_refit_ = true;
   }
 
   // Build TRT engine (if needed) and load TRT engine if:

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider_info.cc
@@ -18,7 +18,9 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
   void* user_compute_stream = nullptr;
   void* user_aux_stream_array = nullptr;
   void* onnx_bytestream = nullptr;
+  size_t onnx_bytestream_size = 0;
   void* external_data_bytestream = nullptr;
+  size_t external_data_bytestream_size = 0;
   ORT_THROW_IF_ERROR(
       ProviderOptionsParser{}
           .AddValueParser(
@@ -62,13 +64,35 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
           .AddAssignmentToReference(nv::provider_option_names::kUseExternalDataInitializer, info.use_external_data_initializer)
           .AddAssignmentToReference(nv::provider_option_names::kMultiProfileEnable, info.multi_profile_enable)
           .AddAssignmentToReference(nv::provider_option_names::kRuntimeCacheFile, info.runtime_cache_path)
-          .Parse(options));  // add new provider option here.
+          .AddAssignmentToReference(nv::provider_option_names::kWeightStrippedEngineEnable, info.weight_stripped_engine_enable)
+          .AddAssignmentToReference(nv::provider_option_names::kOnnxModelFolderPath, info.onnx_model_folder_path)
+          .AddValueParser(
+              nv::provider_option_names::kONNXBytestream,
+              [&onnx_bytestream](const std::string& value_str) -> Status {
+                size_t address;
+                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
+                onnx_bytestream = reinterpret_cast<void*>(address);
+                return Status::OK();
+              })
+          .AddAssignmentToReference(nv::provider_option_names::kONNXBytestreamSize, onnx_bytestream_size)
+          .AddValueParser(
+              nv::provider_option_names::kExternalDataBytestream,
+              [&external_data_bytestream](const std::string& value_str) -> Status {
+                size_t address;
+                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
+                external_data_bytestream = reinterpret_cast<void*>(address);
+                return Status::OK();
+              })
+          .AddAssignmentToReference(nv::provider_option_names::kExternalDataBytestreamSize, external_data_bytestream_size)
+          .Parse(options));
 
   info.user_compute_stream = user_compute_stream;
   info.has_user_compute_stream = (user_compute_stream != nullptr);
   info.user_aux_stream_array = user_aux_stream_array;
   info.onnx_bytestream = onnx_bytestream;
+  info.onnx_bytestream_size = onnx_bytestream_size;
   info.external_data_bytestream = external_data_bytestream;
+  info.external_data_bytestream_size = external_data_bytestream_size;
 
   // EP context settings
   // when EP context is enabled, default is to embed the engine in the context model
@@ -79,8 +103,9 @@ NvExecutionProviderInfo NvExecutionProviderInfo::FromProviderOptions(const Provi
     info.dump_ep_context_model = false;
   } else if (ep_context_enable == "1") {
     info.dump_ep_context_model = true;
-    // We want to reenable weightless engines as soon constant initializers are supported as inputs
-    info.weight_stripped_engine_enable = false;
+    // weight_stripped_engine_enable is preserved from provider options parsing above.
+    // When both ep_context and weight_stripped are enabled, the EP builds weight-stripped engines
+    // (kSTRIP_PLAN + kREFIT_IDENTICAL) and refits weights at inference time from the original ONNX model.
   } else {
     ORT_THROW("Invalid ", kOrtSessionOptionEpContextEnable, " must 0 or 1");
   }
@@ -120,7 +145,13 @@ ProviderOptions NvExecutionProviderInfo::ToProviderOptions(const NvExecutionProv
       {nv::provider_option_names::kProfilesOptShapes, MakeStringWithClassicLocale(info.profile_opt_shapes)},
       {nv::provider_option_names::kCudaGraphEnable, MakeStringWithClassicLocale(info.cuda_graph_enable)},
       {nv::provider_option_names::kUseExternalDataInitializer, MakeStringWithClassicLocale(info.use_external_data_initializer)},
-      {nv::provider_option_names::kRuntimeCacheFile, MakeStringWithClassicLocale(info.runtime_cache_path)}};
+      {nv::provider_option_names::kRuntimeCacheFile, MakeStringWithClassicLocale(info.runtime_cache_path)},
+      {nv::provider_option_names::kWeightStrippedEngineEnable, MakeStringWithClassicLocale(info.weight_stripped_engine_enable)},
+      {nv::provider_option_names::kOnnxModelFolderPath, MakeStringWithClassicLocale(info.onnx_model_folder_path)},
+      {nv::provider_option_names::kONNXBytestream, MakeStringWithClassicLocale(reinterpret_cast<size_t>(info.onnx_bytestream))},
+      {nv::provider_option_names::kONNXBytestreamSize, MakeStringWithClassicLocale(info.onnx_bytestream_size)},
+      {nv::provider_option_names::kExternalDataBytestream, MakeStringWithClassicLocale(reinterpret_cast<size_t>(info.external_data_bytestream))},
+      {nv::provider_option_names::kExternalDataBytestreamSize, MakeStringWithClassicLocale(info.external_data_bytestream_size)}};
   return options;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/nv_ep_context_test.cc
@@ -5,6 +5,7 @@
 #include "test/unittest_util/framework_test_utils.h"
 #include "test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h"
 
+#include <cmath>
 #include <fstream>
 #include <filesystem>
 
@@ -13,6 +14,60 @@ extern std::unique_ptr<Ort::Env> ort_env;
 namespace onnxruntime {
 
 namespace test {
+
+// Helper: Run session with zero-filled FP16 inputs and return output as float vector.
+// Uses session.Run() with CPU tensors to ensure outputs are on CPU (not IoBinding which may return GPU tensors).
+std::vector<float> RunSessionAndGetOutput(Ort::Session& session) {
+  Ort::AllocatorWithDefaultOptions allocator;
+  auto mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+  std::vector<const char*> input_names_c;
+  std::vector<Ort::Value> input_tensors;
+  std::vector<std::vector<uint16_t>> input_buffers;
+
+  for (size_t i = 0; i < session.GetInputCount(); ++i) {
+    auto name = session.GetInputNameAllocated(i, allocator);
+    auto info = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+    auto shape = info.GetShape();
+    auto elem_type = info.GetElementType();
+    for (auto& d : shape) { if (d == -1) d = 1; }
+    size_t num_elements = 1;
+    for (auto d : shape) num_elements *= static_cast<size_t>(d);
+
+    input_buffers.emplace_back(num_elements, uint16_t{0});
+    input_tensors.push_back(Ort::Value::CreateTensor(
+        mem_info, input_buffers.back().data(), num_elements * sizeof(uint16_t),
+        shape.data(), shape.size(), elem_type));
+    input_names_c.push_back(_strdup(name.get()));
+  }
+
+  std::vector<const char*> output_names_c;
+  for (size_t i = 0; i < session.GetOutputCount(); ++i) {
+    auto name = session.GetOutputNameAllocated(i, allocator);
+    output_names_c.push_back(_strdup(name.get()));
+  }
+
+  Ort::RunOptions run_options;
+  auto output_tensors = session.Run(run_options,
+                                     input_names_c.data(), input_tensors.data(), input_tensors.size(),
+                                     output_names_c.data(), output_names_c.size());
+
+  auto type_info = output_tensors[0].GetTensorTypeAndShapeInfo();
+  size_t count = type_info.GetElementCount();
+  std::vector<float> result(count);
+
+  if (type_info.GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+    const uint16_t* data = output_tensors[0].GetTensorData<uint16_t>();
+    for (size_t i = 0; i < count; ++i) result[i] = MLFloat16::FromBits(data[i]).ToFloat();
+  } else {
+    const float* data = output_tensors[0].GetTensorData<float>();
+    std::copy(data, data + count, result.begin());
+  }
+
+  for (auto p : input_names_c) free(const_cast<char*>(p));
+  for (auto p : output_names_c) free(const_cast<char*>(p));
+  return result;
+}
 
 RegisteredEpDeviceUniquePtr AppendTrtEtxEP(Ort::SessionOptions& session_options, std::unordered_map<std::string, std::string>& option_map) {
   RegisteredEpDeviceUniquePtr nv_tensorrt_rtx_ep;
@@ -136,7 +191,7 @@ TEST_P(CompileApiTest, LargeModel) {
   clearFileIfExists(model_name_ctx_data);
   // This accelerates test iterations if the large model was already generated
   if (!std::filesystem::exists(model_name) || !std::filesystem::exists(external_data_name)) {
-    CreateLargeLLMModel(model_name, external_data_name);
+    CreateSimpleMlpModel(model_name, external_data_name, 32, 4096);
   }
 
   Ort::SessionOptions session_options;
@@ -199,6 +254,308 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<CompileApiTest::ParamType>& info) {
       return info.param.to_string();
     });
+
+/*
+ * Test: Weight-stripped engine produces same output as normal engine.
+ *
+ * Uses CreateLargeLLMModel which generates a multi-layer MLP with FP16 MatMul weight
+ * initializers stored as external data. This ensures the model has real weights that
+ * TensorRT can strip from the engine plan (kSTRIP_PLAN) and refit at load time.
+ *
+ * Compiles the same model twice (normal and weight-stripped), runs inference on both
+ * with identical zero-initialized inputs, and verifies that all output values match.
+ */
+TEST(NvExecutionProviderTest, WeightStrippedEngine_OutputMatchesNormal) {
+  PathString model_name = path_utils::MakePathString("nv_ep_weight_stripped_test.onnx");
+  PathString external_data_name = path_utils::MakePathString("nv_ep_weight_stripped_test.onnx_data");
+  PathString ctx_normal = path_utils::MakePathString("nv_ep_weight_stripped_test_normal_ctx.onnx");
+  PathString ctx_stripped = path_utils::MakePathString("nv_ep_weight_stripped_test_stripped_ctx.onnx");
+  clearFileIfExists(ctx_normal);
+  clearFileIfExists(ctx_stripped);
+
+  // Reuse model if already generated from a previous test run
+  if (!std::filesystem::exists(model_name) || !std::filesystem::exists(external_data_name)) {
+    CreateSimpleMlpModel(model_name, external_data_name, 32, 4096);
+  }
+
+  // Helper to compile and run, returning output values
+  auto compile_and_run = [&](bool weight_stripped, const PathString& ctx_path) -> std::vector<float> {
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> option_map{
+        {onnxruntime::nv::provider_option_names::kUseExternalDataInitializer, "1"}};
+    if (weight_stripped) {
+      option_map[onnxruntime::nv::provider_option_names::kWeightStrippedEngineEnable] = "1";
+    }
+    auto ep = AppendTrtEtxEP(session_options, option_map);
+
+    // Compile
+    Ort::ModelCompilationOptions compile_opts(*ort_env, session_options);
+    compile_opts.SetEpContextEmbedMode(false);
+    compile_opts.SetInputModelPath(model_name.c_str());
+    compile_opts.SetOutputModelPath(ctx_path.c_str());
+    EXPECT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+
+    // Load and run using session.Run() with CPU tensors (not IoBinding)
+    Ort::Session session(*ort_env, ctx_path.c_str(), session_options);
+    Ort::AllocatorWithDefaultOptions allocator;
+
+    // Build deterministic input (zero-filled FP16)
+    std::vector<const char*> input_names_c;
+    std::vector<Ort::Value> input_tensors;
+    std::vector<std::vector<uint16_t>> input_buffers;
+    auto mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+    for (size_t i = 0; i < session.GetInputCount(); ++i) {
+      auto name = session.GetInputNameAllocated(i, allocator);
+      auto info = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+      auto shape = info.GetShape();
+      auto elem_type = info.GetElementType();
+      for (auto& d : shape) { if (d == -1) d = 1; }
+      size_t num_elements = 1;
+      for (auto d : shape) num_elements *= static_cast<size_t>(d);
+
+      input_buffers.emplace_back(num_elements, uint16_t{0});  // zero-filled FP16
+      input_tensors.push_back(Ort::Value::CreateTensor(
+          mem_info, input_buffers.back().data(), num_elements * sizeof(uint16_t),
+          shape.data(), shape.size(), elem_type));
+      input_names_c.push_back(_strdup(name.get()));
+    }
+
+    std::vector<const char*> output_names_c;
+    for (size_t i = 0; i < session.GetOutputCount(); ++i) {
+      auto name = session.GetOutputNameAllocated(i, allocator);
+      output_names_c.push_back(_strdup(name.get()));
+    }
+
+    Ort::RunOptions run_options;
+    auto output_tensors = session.Run(run_options,
+                                       input_names_c.data(), input_tensors.data(), input_tensors.size(),
+                                       output_names_c.data(), output_names_c.size());
+
+    EXPECT_FALSE(output_tensors.empty());
+    EXPECT_TRUE(output_tensors[0].IsTensor());
+
+    auto type_info = output_tensors[0].GetTensorTypeAndShapeInfo();
+    size_t count = type_info.GetElementCount();
+
+    // Copy to float vector for comparison
+    std::vector<float> result(count);
+    auto elem_type = type_info.GetElementType();
+    if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+      const uint16_t* data = output_tensors[0].GetTensorData<uint16_t>();
+      for (size_t i = 0; i < count; ++i) {
+        result[i] = MLFloat16::FromBits(data[i]).ToFloat();
+      }
+    } else {
+      const float* data = output_tensors[0].GetTensorData<float>();
+      std::copy(data, data + count, result.begin());
+    }
+
+    for (auto p : input_names_c) free(const_cast<char*>(p));
+    for (auto p : output_names_c) free(const_cast<char*>(p));
+    return result;
+  };
+
+  // Run both modes
+  auto output_normal = compile_and_run(false, ctx_normal);
+  auto output_stripped = compile_and_run(true, ctx_stripped);
+
+  // Verify outputs match
+  ASSERT_EQ(output_normal.size(), output_stripped.size());
+  ASSERT_FALSE(output_normal.empty());
+
+  float max_diff = 0.0f;
+  for (size_t i = 0; i < output_normal.size(); ++i) {
+    float diff = std::abs(output_normal[i] - output_stripped[i]);
+    max_diff = std::max(max_diff, diff);
+  }
+
+  EXPECT_LT(max_diff, 0.001f)
+      << "Max absolute difference between normal and weight-stripped outputs: " << max_diff;
+
+  // Cleanup context files (keep the large model for reuse across test runs)
+  clearFileIfExists(ctx_normal);
+  clearFileIfExists(ctx_stripped);
+  for (auto& entry : std::filesystem::directory_iterator(".")) {
+    if (entry.path().extension() == ".engine" &&
+        entry.path().string().find("NvTensorRTRTX") != std::string::npos) {
+      std::filesystem::remove(entry.path());
+    }
+  }
+}
+
+/*
+ * Test: Weight-stripped engine file is significantly smaller than normal engine.
+ *
+ * Compiles the same LLM model in both modes and compares .engine file sizes.
+ * Weight-stripped engines should be orders of magnitude smaller since they
+ * contain only the network structure, not the weight data.
+ */
+TEST(NvExecutionProviderTest, WeightStrippedEngine_EngineSizeReduction) {
+  PathString model_name = path_utils::MakePathString("nv_ep_weight_stripped_size_test.onnx");
+  PathString external_data_name = path_utils::MakePathString("nv_ep_weight_stripped_size_test.onnx_data");
+  PathString ctx_normal = path_utils::MakePathString("nv_ep_weight_stripped_size_normal_ctx.onnx");
+  PathString ctx_stripped = path_utils::MakePathString("nv_ep_weight_stripped_size_stripped_ctx.onnx");
+  clearFileIfExists(ctx_normal);
+  clearFileIfExists(ctx_stripped);
+
+  // Use hidden_dim=2048 so weights (~64MB) dominate engine size and stripping shows a clear reduction
+  if (!std::filesystem::exists(model_name) || !std::filesystem::exists(external_data_name)) {
+    CreateSimpleMlpModel(model_name, external_data_name, 32, 4096);
+  }
+
+  auto compile_model = [&](bool weight_stripped, const PathString& ctx_path) {
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> option_map{
+        {onnxruntime::nv::provider_option_names::kUseExternalDataInitializer, "1"}};
+    if (weight_stripped) {
+      option_map[onnxruntime::nv::provider_option_names::kWeightStrippedEngineEnable] = "1";
+    }
+    auto ep = AppendTrtEtxEP(session_options, option_map);
+
+    Ort::ModelCompilationOptions compile_opts(*ort_env, session_options);
+    compile_opts.SetEpContextEmbedMode(false);
+    compile_opts.SetInputModelPath(model_name.c_str());
+    compile_opts.SetOutputModelPath(ctx_path.c_str());
+    ASSERT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+  };
+
+  // Find engine files by scanning for .engine files with NvTensorRTRTX in the name
+  auto find_engine_size = []() -> uintmax_t {
+    uintmax_t total = 0;
+    for (auto& entry : std::filesystem::directory_iterator(".")) {
+      if (entry.path().extension() == ".engine" &&
+          entry.path().string().find("NvTensorRTRTX") != std::string::npos) {
+        total += entry.file_size();
+      }
+    }
+    return total;
+  };
+
+  auto cleanup_engines = []() {
+    for (auto& entry : std::filesystem::directory_iterator(".")) {
+      if (entry.path().extension() == ".engine" &&
+          entry.path().string().find("NvTensorRTRTX") != std::string::npos) {
+        std::filesystem::remove(entry.path());
+      }
+    }
+  };
+
+  // Compile normal
+  cleanup_engines();
+  compile_model(false, ctx_normal);
+  uintmax_t normal_size = find_engine_size();
+  ASSERT_GT(normal_size, 0u) << "Normal engine file should exist";
+
+  // Compile weight-stripped
+  cleanup_engines();
+  compile_model(true, ctx_stripped);
+  uintmax_t stripped_size = find_engine_size();
+  ASSERT_GT(stripped_size, 0u) << "Weight-stripped engine file should exist";
+
+  // Weight-stripped should be at least 10x smaller
+  EXPECT_LT(stripped_size, normal_size / 10)
+      << "Weight-stripped engine (" << stripped_size << " bytes) should be much smaller than "
+      << "normal engine (" << normal_size << " bytes)";
+
+  // Cleanup
+  cleanup_engines();
+  clearFileIfExists(ctx_normal);
+  clearFileIfExists(ctx_stripped);
+}
+
+/*
+ * Test: Load pre-compiled weight-stripped context model and refit from ONNX bytestream.
+ *
+ * This mirrors the TensorRT EP's "Refit weightless context model with ONNX in memory" test.
+ * Step 1: Compile a weight-stripped context model
+ * Step 2: Load the context model in a new session with the ONNX model provided as bytestream
+ * Step 3: Run inference and verify output matches the normal compilation
+ */
+TEST(NvExecutionProviderTest, WeightStrippedEngine_RefitFromBytestream) {
+  PathString model_name = path_utils::MakePathString("nv_ep_weight_stripped_refit_bs.onnx");
+  PathString external_data_name = path_utils::MakePathString("nv_ep_weight_stripped_refit_bs.onnx_data");
+  PathString ctx_normal = path_utils::MakePathString("nv_ep_weight_stripped_refit_bs_normal_ctx.onnx");
+  PathString ctx_stripped = path_utils::MakePathString("nv_ep_weight_stripped_refit_bs_stripped_ctx.onnx");
+  clearFileIfExists(ctx_normal);
+  clearFileIfExists(ctx_stripped);
+
+  if (!std::filesystem::exists(model_name) || !std::filesystem::exists(external_data_name)) {
+    CreateSimpleMlpModel(model_name, external_data_name, 32, 4096);
+  }
+
+  // Step 1: Compile normal context model for reference output
+  std::vector<float> output_normal;
+  {
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> option_map{
+        {onnxruntime::nv::provider_option_names::kUseExternalDataInitializer, "1"}};
+    auto ep = AppendTrtEtxEP(session_options, option_map);
+
+    Ort::ModelCompilationOptions compile_opts(*ort_env, session_options);
+    compile_opts.SetEpContextEmbedMode(false);
+    compile_opts.SetInputModelPath(model_name.c_str());
+    compile_opts.SetOutputModelPath(ctx_normal.c_str());
+    ASSERT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+
+    Ort::Session session(*ort_env, ctx_normal.c_str(), session_options);
+    output_normal = RunSessionAndGetOutput(session);
+  }
+
+  // Step 2: Compile weight-stripped context model
+  {
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> option_map{
+        {onnxruntime::nv::provider_option_names::kUseExternalDataInitializer, "1"},
+        {onnxruntime::nv::provider_option_names::kWeightStrippedEngineEnable, "1"}};
+    auto ep = AppendTrtEtxEP(session_options, option_map);
+
+    Ort::ModelCompilationOptions compile_opts(*ort_env, session_options);
+    compile_opts.SetEpContextEmbedMode(false);
+    compile_opts.SetInputModelPath(model_name.c_str());
+    compile_opts.SetOutputModelPath(ctx_stripped.c_str());
+    ASSERT_TRUE(Ort::CompileModel(*ort_env, compile_opts).IsOK());
+  }
+
+  // Step 3: Load the weight-stripped context model with ONNX bytestream for refit
+  std::vector<float> output_refit;
+  {
+    auto onnx_bytes = readBinaryFile(model_name);
+    auto ext_data_bytes = readBinaryFile(external_data_name);
+
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> option_map{
+        {onnxruntime::nv::provider_option_names::kUseExternalDataInitializer, "1"},
+        {onnxruntime::nv::provider_option_names::kWeightStrippedEngineEnable, "1"},
+        {onnxruntime::nv::provider_option_names::kONNXBytestream, std::to_string(reinterpret_cast<size_t>(onnx_bytes.data()))},
+        {onnxruntime::nv::provider_option_names::kONNXBytestreamSize, std::to_string(onnx_bytes.size())},
+        {onnxruntime::nv::provider_option_names::kExternalDataBytestream, std::to_string(reinterpret_cast<size_t>(ext_data_bytes.data()))},
+        {onnxruntime::nv::provider_option_names::kExternalDataBytestreamSize, std::to_string(ext_data_bytes.size())}};
+    auto ep = AppendTrtEtxEP(session_options, option_map);
+
+    Ort::Session session(*ort_env, ctx_stripped.c_str(), session_options);
+    output_refit = RunSessionAndGetOutput(session);
+  }
+
+  // Verify outputs match
+  ASSERT_EQ(output_normal.size(), output_refit.size());
+  float max_diff = 0.0f;
+  for (size_t i = 0; i < output_normal.size(); ++i) {
+    max_diff = std::max(max_diff, std::abs(output_normal[i] - output_refit[i]));
+  }
+  EXPECT_LT(max_diff, 0.001f)
+      << "Bytestream-refitted output should match normal output. Max diff: " << max_diff;
+
+  // Cleanup
+  clearFileIfExists(ctx_normal);
+  clearFileIfExists(ctx_stripped);
+  for (auto& entry : std::filesystem::directory_iterator(".")) {
+    if (entry.path().extension() == ".engine" &&
+        entry.path().string().find("NvTensorRTRTX") != std::string::npos) {
+      std::filesystem::remove(entry.path());
+    }
+  }
+}
 
 /*
  * Helper to create a synthetic EPContext ONNX model with a specific "source" attribute.

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.cc
@@ -15,6 +15,7 @@
 #include "core/graph/basic_types.h"
 #include "core/graph/model.h"
 #include "core/graph/onnx_protobuf.h"
+#include "core/framework/tensorprotoutils.h"
 #include "core/graph/model_saving_options.h"
 #include "core/graph/schema_registry.h"
 #include "test/util/include/scoped_env_vars.h"
@@ -413,6 +414,50 @@ void CreateLargeLLMModel(const PathString& model_path, const PathString& externa
   graph.AddNode("Output_Linear", "MatMul", "", {current_arg, graph.GetNodeArg(w_logits.name())}, {&output});
 
   // Validate, Write as large model with external data
+  auto status = graph.Resolve();
+  if (!status.IsOK()) throw std::runtime_error(status.ErrorMessage());
+
+  onnxruntime::ModelSavingOptions save_options(128);
+  status = onnxruntime::Model::SaveWithExternalInitializers(
+      model, model_path, external_data_path, save_options);
+  if (!status.IsOK()) throw std::runtime_error(status.ErrorMessage());
+}
+
+void CreateSimpleMlpModel(const PathString& model_path, const PathString& external_data_path,
+                           int num_layers, int hidden_dim) {
+  auto dtype = ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
+  int batch_size = 1;
+  int seq_length = 32;
+
+  onnxruntime::Model model("SimpleMLP", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  // Input
+  ONNX_NAMESPACE::TypeProto input_type;
+  input_type.mutable_tensor_type()->set_elem_type(dtype);
+  input_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(batch_size);
+  input_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(seq_length);
+  input_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(hidden_dim);
+  auto& input = graph.GetOrCreateNodeArg("input", &input_type);
+  auto* current = &input;
+
+  for (int l = 0; l < num_layers; ++l) {
+    auto w = CreateLargeWeight("w_" + std::to_string(l), dtype, {hidden_dim, hidden_dim});
+    graph.AddInitializedTensor(w);
+
+    auto& mm_out = graph.GetOrCreateNodeArg("mm_" + std::to_string(l), nullptr);
+    graph.AddNode("MatMul_" + std::to_string(l), "MatMul", "", {current, graph.GetNodeArg(w.name())}, {&mm_out});
+
+    auto& relu_out = graph.GetOrCreateNodeArg("relu_" + std::to_string(l), nullptr);
+    graph.AddNode("Relu_" + std::to_string(l), "Relu", "", {&mm_out}, {&relu_out});
+
+    current = &relu_out;
+  }
+
+  // Final output (rename)
+  auto& output = graph.GetOrCreateNodeArg("output", nullptr);
+  graph.AddNode("Identity_out", "Identity", "", {current}, {&output});
+
   auto status = graph.Resolve();
   if (!status.IsOK()) throw std::runtime_error(status.ErrorMessage());
 

--- a/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
+++ b/onnxruntime/test/providers/nv_tensorrt_rtx/test_nv_trt_rtx_ep_util.h
@@ -119,6 +119,19 @@ void CreateBaseModel(const PathString& model_name,
 
 void CreateLargeLLMModel(const PathString& model_path, const PathString& external_data_path);
 
+/**
+ * Create a simple multi-layer MLP model with FP16 MatMul weight initializers stored externally.
+ * Uses only standard ONNX ops (MatMul + Relu) that are fully supported by TensorRT.
+ * Suitable for testing weight-stripped engine compilation and refitting.
+ *
+ * \param model_path - output model file name
+ * \param external_data_path - output external data file name
+ * \param num_layers - number of MatMul+Relu layers (default 4)
+ * \param hidden_dim - hidden dimension (default 256)
+ */
+void CreateSimpleMlpModel(const PathString& model_path, const PathString& external_data_path,
+                           int num_layers = 4, int hidden_dim = 256);
+
 Ort::IoBinding generate_io_binding(
     Ort::Session& session,
     std::map<std::string, std::vector<int64_t>> shape_overwrites = {},


### PR DESCRIPTION
Add support for weightless EP context

### Compile
```cpp
Ort::SessionOptions opts;
opts.AppendExecutionProvider_V2(env, {ep_device}, {
    {"nv_use_external_data_initializer", "1"},
    {"nv_weight_stripped_engine_enable", "1"},
});

Ort::ModelCompilationOptions compile_opts(env, opts);
compile_opts.SetInputModelPath(ORT_TSTR(model_path));
compile_opts.SetOutputModelPath(ORT_TSTR(ctx_path));
compile_opts.SetEpContextEmbedMode(true); 

Ort::CompileModel(env, compile_opts);
```

### Inference
```cpp
Ort::SessionOptions opts;
opts.AppendExecutionProvider_V2(env, {ep_device}, {
    {"nv_use_external_data_initializer", "1"},
    {"nv_weight_stripped_engine_enable", "1"},
    {"nv_onnx_bytestream", std::to_string(onnx_bytes.data())},
    {"nv_onnx_bytestream_size", std::to_string(onnx_bytes.size())},
    {"nv_external_data_bytestream", std::to_string(weights_data.data())},
    {"nv_external_data_bytestream_size", std::to_string(weights_data.size())},
});

// load EP context model
Ort::Session session(env, ctx_buffer, opts);
```

